### PR TITLE
Create pip-installable Python package

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -28,7 +28,7 @@ We use an evironment with the following specifications, packages and dependencie
   cd OneFormer
 
   # Install Pytorch
-  conda install pytorch==1.10.1 torchvision==0.11.2 cudatoolkit=11.3 -c pytorch -c conda-forge
+  conda install pytorch==1.10.1 torchvision==0.11.2 cudatoolkit-dev=11.3 -c pytorch -c conda-forge
 
   # Install opencv (required for running the demo)
   pip3 install -U opencv-python

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -14,14 +14,14 @@ We use an evironment with the following specifications, packages and dependencie
 
 ## Setup Instructions
 
-- Create a conda environment
+- Create a conda environment:
   
   ```bash
   conda create --name oneformer python=3.8 -y
   conda activate oneformer
   ```
 
-- Install packages and other dependencies.
+- Install packages and other dependencies:
 
   ```bash
   git clone https://github.com/SHI-Labs/OneFormer.git
@@ -34,7 +34,8 @@ We use an evironment with the following specifications, packages and dependencie
   pip3 install -U opencv-python
 
   # Install detectron2
-  python tools/setup_detectron2.py
+  python -m pip install 'git+https://github.com/facebookresearch/detectron2.git#egg=detectron2'
+  # OR: python tools/setup_detectron2.py
 
   # Install other dependencies
   pip3 install git+https://github.com/cocodataset/panopticapi.git
@@ -42,20 +43,26 @@ We use an evironment with the following specifications, packages and dependencie
   pip3 install -r requirements.txt
   ```
 
-- Setup wandb.
+- Install OneFormer in development mode:
+
+  From repo root (`OneFormer/`), run:
+  ```bash
+  pip install -e .
+  ```
+
+- Setup wandb:
 
   ```bash
-  # Setup wand
   pip3 install wandb
   wandb login
   ```
 
-- Setup CUDA Kernel for MSDeformAttn. `CUDA_HOME` must be defined and points to the directory of the installed CUDA toolkit.
+- Setup CUDA Kernel for MSDeformAttn (`CUDA_HOME` must be defined, pointing to the directory of the installed CUDA toolkit):
 
   ```bash
   # Setup MSDeformAttn
-  cd oneformer/modeling/pixel_decoder/ops
+  pushd oneformer/modeling/pixel_decoder/ops
   sh make.sh
-  cd ../../../..
+  popd
   ```
   

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -28,13 +28,13 @@ We use an evironment with the following specifications, packages and dependencie
   cd OneFormer
 
   # Install Pytorch
-  conda install pytorch==1.10.1 torchvision==0.11.2 cudatoolkit-dev=11.3 -c pytorch -c conda-forge
+  conda install pytorch==1.10.1 torchvision==0.11.2 cudatoolkit=11.3 cudatoolkit-dev=11.3 -c pytorch -c conda-forge
 
   # Install opencv (required for running the demo)
   pip3 install -U opencv-python
 
   # Install detectron2
-  python -m pip install 'git+https://github.com/facebookresearch/detectron2.git#egg=detectron2'
+  pip3 install 'git+https://github.com/facebookresearch/detectron2.git#egg=detectron2'
   # OR: python tools/setup_detectron2.py
 
   # Install other dependencies
@@ -47,7 +47,7 @@ We use an evironment with the following specifications, packages and dependencie
 
   From repo root (`OneFormer/`), run:
   ```bash
-  pip install -e .
+  pip3 install -e .
   ```
 
 - Setup wandb:

--- a/demo/demo.py
+++ b/demo/demo.py
@@ -8,10 +8,6 @@ import multiprocessing as mp
 import os
 import torch
 import random
-# fmt: off
-import sys
-sys.path.insert(1, os.path.join(sys.path[0], '..'))
-# fmt: on
 
 import time
 import cv2
@@ -107,7 +103,6 @@ if __name__ == "__main__":
     if args.input:
         for path in tqdm.tqdm(args.input, disable=not args.output):
             # use PIL, to be consistent with evaluation
-                
             img = read_image(path, format="BGR")
             start_time = time.time()
             predictions, visualized_output = demo.run_on_image(img, args.task)
@@ -125,14 +120,23 @@ if __name__ == "__main__":
                     for k in visualized_output.keys():
                         os.makedirs(k, exist_ok=True)
                         out_filename = os.path.join(k, args.output)
-                        visualized_output[k].save(out_filename)    
+                        visualized_output[k].save(out_filename)
                 else:
                     for k in visualized_output.keys():
-                        opath = os.path.join(args.output, k)    
+                        opath = os.path.join(args.output, k)
                         os.makedirs(opath, exist_ok=True)
                         out_filename = os.path.join(opath, os.path.basename(path))
-                        visualized_output[k].save(out_filename)    
+                        visualized_output[k].save(out_filename)
             else:
-                raise ValueError("Please specify an output path!")
+                logger.debug("No output path specified; displaying output image(s)")
+                try:
+                    for k in visualized_output.keys():
+                        window_title = f"{WINDOW_NAME}: {k}"
+                        cv2.imshow(window_title, visualized_output[k].get_image())
+                        cv2.waitKey(1)
+                    print("Press any key...")
+                    cv2.waitKey(-1)  # blocking
+                finally:
+                    cv2.destroyAllWindows()
     else:
         raise ValueError("No Input Given")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 cython
+numpy<1.24.0
 scipy==1.8.1
 shapely
 h5py==3.7.0

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,58 @@
+"""OneFormer: One Transformer to Rule Universal Image Segmentation"""
+
+import pathlib
+import shlex
+import subprocess
+import warnings
+
+from pkg_resources import parse_requirements
+from setuptools import setup, find_packages
+
+# Package version
+VERSION = '1.0.0'
+
+def version(base_version=VERSION, default_branch='main'):
+    """Prepare SCM-aware package version string."""
+    branch_name = subprocess.check_output(shlex.split("git rev-parse --abbrev-ref HEAD"), text=True).strip()
+    if branch_name == default_branch:
+        return base_version
+    else:
+        short_commit_sha = subprocess.check_output(shlex.split("git rev-parse --short HEAD"), text=True).strip()
+        return f'{base_version}+g{short_commit_sha}'
+
+
+# Packages to install
+packages = find_packages(exclude=('tests', 'tests.*'))
+
+# Parse dependencies from requirements.txt
+install_requires = []
+try:
+    with pathlib.Path('requirements.txt').open() as requirements_txt:
+        install_requires = [
+            str(requirement) \
+            for requirement in parse_requirements(requirements_txt)
+        ]
+except Exception as e:
+    warnings.warn(f"Unable to parse requirements! {type(e).__name__}: {str(e)}")
+
+# Extras
+extras_require = {}
+extras_require['all'] = list(set(
+    dep for dep_list in extras_require.values() for dep in dep_list))  # magic: all except test
+
+tests_require = []
+extras_require['test'] = tests_require  # magic: test only
+
+# Setup with metadata
+setup(
+    name='oneformer',
+    version=version(),
+    description='OneFormer: One Transformer to Rule Universal Image Segmentation',
+    url='https://github.com/SHI-Labs/OneFormer',
+    author='Jitesh Jain',
+    author_email='jitesh.jj2@gmail.com',
+    packages=packages,
+    install_requires=install_requires,
+    extras_require=extras_require,
+    tests_require=tests_require
+)

--- a/tools/analyze_model.py
+++ b/tools/analyze_model.py
@@ -16,12 +16,6 @@ from detectron2.utils.analysis import (
 )
 from detectron2.utils.logger import setup_logger
 
-# fmt: off
-import os
-import sys
-sys.path.insert(1, os.path.join(sys.path[0], '..'))
-# fmt: on
-
 from oneformer.data.build import *
 from oneformer.data.dataset_mappers.dataset_mapper import DatasetMapper
 from oneformer import (

--- a/tools/calc_throughput.py
+++ b/tools/calc_throughput.py
@@ -19,12 +19,6 @@ from detectron2.solver.build import maybe_add_gradient_clipping
 from detectron2.utils.logger import setup_logger
 from trainers.trainer import TPDefaultTrainer
 
-# fmt: off
-import os
-import sys
-sys.path.insert(1, os.path.join(sys.path[0], '..'))
-# fmt: on
-
 from oneformer import (
     COCOUnifiedNewBaselineDatasetMapper,
     OneFormerUnifiedDatasetMapper,

--- a/tools/setup_detectron2.py
+++ b/tools/setup_detectron2.py
@@ -1,4 +1,4 @@
-import sys, os, distutils.core, subprocess
+import os, distutils.core, subprocess
 
 if not os.path.exists('./detectron2'):
     subprocess.run(['git', 'clone', 'https://github.com/facebookresearch/detectron2'])
@@ -7,5 +7,3 @@ dist = distutils.core.run_setup("./detectron2/setup.py")
 
 for x in dist.install_requires:
     subprocess.run(['python', '-m', 'pip', 'install', x])
-
-sys.path.insert(0, os.path.abspath('./detectron2'))


### PR DESCRIPTION
- [x] Add setup.py for oneformer package
- [x] Update install instructions
- [x] Update instructions to setup detectron2 (~include it as a dep in requirements.txt~)
- [x] Update demo code to avoid munging sys.path (use installed package instead)
- [x] Test demo, ~training~ and eval code

To install the package, follow instructions in [INSTALL.md](https://github.com/Ridecell/OneFormer/blob/arpan/feature/python-packaging/INSTALL.md) (clone this repo and PR branch instead of upstream).

To run a demo (try running from outside the repo to test out package installation):
```bash
python OneFormer/demo/demo.py \
    --config-file </path/to/config.yaml> \
    --task <panoptic|segmentation|instance> \
    --input </path/to/images> \
    --opts MODEL.IS_TRAIN False MODEL.IS_DEMO True MODEL.WEIGHTS </path/to/weights.pth>
```